### PR TITLE
Fix meta charset

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-M">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Link to Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- fix typo in charset meta tag to use UTF-8

## Testing
- `pytest -q`
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853a977f270832eb2a6d94d6dad05d7